### PR TITLE
feat: Sync usnysced days

### DIFF
--- a/crates/moneyman/src/persistence/seed.rs
+++ b/crates/moneyman/src/persistence/seed.rs
@@ -10,45 +10,141 @@ use crate::persistence::{self, fallback::fetch_neighboring_rates};
 /// Seeds the DB with the history of exchange rates
 pub(crate) fn seed_db(conn: &Connection, data_dir: &Path) -> Result<(), rusqlite::Error> {
     let csv_path = data_dir.join("eurofxref-hist.csv");
-
-    copy_from_csv(conn, &csv_path)
-        .and_then(|_| clean_up_na(conn))
-        .and_then(|_| precompute_interpolated_rates(conn))
+    let interpolation_start_date = copy_from_csv(conn, &csv_path)?;
+    clean_up_na(conn)?;
+    precompute_interpolated_rates(conn, interpolation_start_date)
 }
 
 /// Creates a virtual table `vrates` from the CSV
-fn copy_from_csv(conn: &Connection, csv_path: &Path) -> Result<(), rusqlite::Error> {
+fn copy_from_csv(conn: &Connection, csv_path: &Path) -> Result<NaiveDate, rusqlite::Error> {
     csvtab::load_module(conn)?;
 
-    let script = format!(
-        "
-        BEGIN;
+    let latest_date_script = "
+        SELECT Date
+            FROM rates
+            ORDER BY Date DESC
+            LIMIT 1
+    ";
 
-            DROP TABLE IF EXISTS rates;
-            DROP TABLE IF EXISTS vrates;
+    let latest_entry = conn
+        .prepare_cached(latest_date_script)
+        .and_then(|mut stmt| stmt.query_row((), |row| row.get::<usize, NaiveDate>(0)));
 
-            CREATE VIRTUAL TABLE vrates
-                USING csv
-                    ( filename={}
-                    , header=yes
-                    );
+    match latest_entry {
+        Ok(latest_date) => {
+            let script = format!(
+                "
+                BEGIN;
+                    DROP TABLE IF EXISTS vrates;
 
-            CREATE TABLE rates AS SELECT * FROM vrates;
+                    CREATE VIRTUAL TABLE vrates
+                        USING csv
+                            ( filename={}
+                            , header=yes
+                            );
 
-            ALTER TABLE rates ADD COLUMN Interpolated BOOLEAN;
-            ALTER TABLE rates DROP COLUMN \"\";
+                    INSERT INTO rates
+                        SELECT Date
+                             , USD
+                             , JPY
+                             , BGN
+                             , CYP
+                             , CZK
+                             , DKK
+                             , EEK
+                             , GBP
+                             , HUF
+                             , LTL
+                             , LVL
+                             , MTL
+                             , PLN
+                             , ROL
+                             , RON
+                             , SEK
+                             , SIT
+                             , SKK
+                             , CHF
+                             , ISK
+                             , NOK
+                             , HRK
+                             , RUB
+                             , TRL
+                             , TRY
+                             , AUD
+                             , BRL
+                             , CAD
+                             , CNY
+                             , HKD
+                             , IDR
+                             , ILS
+                             , INR
+                             , KRW
+                             , MXN
+                             , MYR
+                             , NZD
+                             , PHP
+                             , SGD
+                             , THB
+                             , ZAR
+                             , false
+                            FROM vrates
+                            WHERE Date >= '{}'
+                            ORDER BY Date DESC;
+                COMMIT;
 
-            UPDATE rates SET Interpolated = false;
+                ",
+                csv_path.to_str().expect("expected a UTF-8 path"),
+                latest_date.succ_opt().unwrap().to_string()
+            );
 
-            CREATE UNIQUE INDEX date_index ON rates(Date, Interpolated);
+            conn.execute_batch(script.as_str())?;
+            Ok(latest_date)
+        }
+        Err(err @ rusqlite::Error::QueryReturnedNoRows)
+        | Err(err @ rusqlite::Error::SqliteFailure(_, _)) => {
+            if let rusqlite::Error::SqliteFailure(error1, Some(err_str)) = err {
+                match err_str.as_str() {
+                    "no such table: rates" => {
+                        let script = format!(
+                            "
+                            BEGIN;
+                                DROP TABLE IF EXISTS vrates;
+                                DROP TABLE IF EXISTS rates;
 
-            DROP TABLE vrates;
-        COMMIT;
-        ",
-        csv_path.to_str().expect("expected a UTF-8 path")
-    );
+                                CREATE VIRTUAL TABLE vrates
+                                    USING csv
+                                        ( filename={}
+                                        , header=yes
+                                        );
 
-    conn.execute_batch(script.as_str())
+                                CREATE TABLE rates AS SELECT * FROM vrates;
+
+                                ALTER TABLE rates ADD COLUMN Interpolated BOOLEAN;
+                                ALTER TABLE rates DROP COLUMN \"\";
+
+                                UPDATE rates SET Interpolated = false;
+
+                                CREATE UNIQUE INDEX date_index ON rates(Date);
+                                CREATE INDEX date_interpolated_index ON rates(Date, Interpolated);
+
+                                DROP TABLE vrates;
+                            COMMIT;
+                            ",
+                            csv_path.to_str().expect("expected a UTF-8 path")
+                        );
+
+                        conn.execute_batch(script.as_str())?;
+                        Ok(NaiveDate::from_ymd_opt(1999, 1, 4).unwrap())
+                    }
+
+                    _ => Err(rusqlite::Error::SqliteFailure(error1, Some(err_str))),
+                }
+            } else {
+                Err(err)
+            }
+        }
+        Err(err) => Err(err),
+    }
 }
 
 /// Sets rows with "N/A" to actual NULL values
@@ -68,7 +164,10 @@ fn clean_up_na(conn: &Connection) -> Result<(), rusqlite::Error> {
     (*conn).execute_batch(statements.as_ref())
 }
 
-fn precompute_interpolated_rates(conn: &Connection) -> Result<(), rusqlite::Error> {
+fn precompute_interpolated_rates(
+    conn: &Connection,
+    start_date: NaiveDate,
+) -> Result<(), rusqlite::Error> {
     let currencies = [
         iso::USD,
         iso::JPY,
@@ -106,14 +205,12 @@ fn precompute_interpolated_rates(conn: &Connection) -> Result<(), rusqlite::Erro
     ];
 
     let selectable_columns = currencies.map(|c| c.iso_alpha_code).join(", ");
+    let mut latest_date_statement =
+        conn.prepare("SELECT Date FROM rates ORDER BY Date DESC LIMIT 1")?;
 
-    let mut first_date_statement = conn.prepare("SELECT Date FROM rates ORDER BY Date ASC")?;
-    let mut latest_date_statement = conn.prepare("SELECT Date FROM rates ORDER BY Date DESC")?;
-
-    let first_date = first_date_statement.query_row((), |row| row.get::<usize, NaiveDate>(0))?;
     let latest_date = latest_date_statement.query_row((), |row| row.get::<usize, NaiveDate>(0))?;
 
-    first_date
+    start_date
         .iter_days()
         // Skip the first date since the first date should always have a rate
         .skip(1)
@@ -121,7 +218,6 @@ fn precompute_interpolated_rates(conn: &Connection) -> Result<(), rusqlite::Erro
         // a rate
         .take_while(|date| *date < latest_date)
         .map(|date| {
-            dbg!(date);
             let neighbors = fetch_neighboring_rates(conn, &currencies, date)?;
 
             // FIXME: Need to find a way to get rid of this `.expect()`

--- a/crates/moneyman/src/persistence/seed.rs
+++ b/crates/moneyman/src/persistence/seed.rs
@@ -94,7 +94,7 @@ fn copy_from_csv(conn: &Connection, csv_path: &Path) -> Result<NaiveDate, rusqli
 
                 ",
                 csv_path.to_str().expect("expected a UTF-8 path"),
-                latest_date.succ_opt().unwrap().to_string()
+                latest_date.succ_opt().unwrap()
             );
 
             conn.execute_batch(script.as_str())?;

--- a/crates/moneyman_cli/src/main.rs
+++ b/crates/moneyman_cli/src/main.rs
@@ -9,7 +9,7 @@ fn main() {
         .map(|home_dir| home_dir.join(".moneyman"))
         .expect("need a home directory");
 
-    let store = moneyman::ExchangeStore::open(data_dir).expect("failed ze sync");
+    let store = moneyman::ExchangeStore::sync(data_dir).expect("failed ze sync");
 
     let amount_in_usd = Money::from_decimal(dec!(6500), iso::USD);
     let _amount_in_eur = Money::from_decimal(dec!(1000), iso::EUR);


### PR DESCRIPTION
This is to prevent syncing everything all over again even if all that's missing are only a few days. This will also interpolate from the last known date, until the most recent one in the ECB history, if applicable. But this only does it from the last checkpoint. The latest date in the current data store will be assumed as the checkpoint. Meaning, if the data store were to be tampered by removing some data somewhere in between the bounds, this won't get fixed.